### PR TITLE
Describes all differences between the horizontal and vertical versions

### DIFF
--- a/charts/BarCharts/index.Rmd
+++ b/charts/BarCharts/index.Rmd
@@ -116,7 +116,7 @@ highchart() %>%
 ```
 
 
-The `highcharter` library distinguishes between horizontal and vertically orientated bar charts by `hc_chart(type = )`; column and bar are verticle and horizontal, respectively. Both varieties of chart are more legible if bars are ordered from largest to smallest, note that internal to `hc_add_series` the ordered `measure_column` is reversed to achieve this:
+The `highcharter` library distinguishes between horizontal and vertically orientated bar charts by `hc_chart(type = )`; column and bar are verticle and horizontal, respectively. Both varieties of chart are more legible if bars are ordered from largest to smallest. We also add a label for the Y axis. Note that internal to `hc_add_series` the ordered `measure_column` is reversed to achieve this:
 
 ```{r}
 aggregate_mean <- aggregate_mean[order(aggregate_mean$Desktop.Items),]


### PR DESCRIPTION
By the way not clear if "rev' is not needed if the sort is descending:

order(-aggregate_mean$Desktop.Items)

Perhaps this should all be simplified by labelling the Y axis in both examples and then only the following is needed:

aggregate_mean <- aggregate_mean[order(-aggregate_mean$Desktop.Items),]

in which case not clear need to repeat the rest of the code.
